### PR TITLE
Fix nested Intermediary classes not being cached

### DIFF
--- a/module/mapping/src/main/java/net/fabricmc/discord/bot/module/mapping/MappingData.java
+++ b/module/mapping/src/main/java/net/fabricmc/discord/bot/module/mapping/MappingData.java
@@ -77,7 +77,7 @@ final class MappingData {
 					int idStart;
 
 					if (outerEnd >= 0 && imName.startsWith(intermediaryClassPrefix, outerEnd + 1)) { // nested intermediary: bla$class_123
-						idStart = outerEnd + intermediaryClassPrefix.length();
+						idStart = outerEnd + 1 + intermediaryClassPrefix.length();
 					} else if (outerEnd < 0 && imName.startsWith(intermediaryFullClassPrefix)) { // regular intermediary: net/minecraft/class_123
 						idStart = intermediaryFullClassPrefix.length();
 					} else {


### PR DESCRIPTION
Right now `net/minecraft/class_1$class_2` is being shortened to `_2` which obviously can't be interpreted as a number